### PR TITLE
Add UNet resize-conv layers

### DIFF
--- a/neuralprocesses/architectures/convgnp.py
+++ b/neuralprocesses/architectures/convgnp.py
@@ -22,6 +22,7 @@ def construct_convgnp(nps):
         unet_channels=(64,) * 6,
         unet_activations=None,
         unet_kernels=5,
+        unet_use_resize_convs=True,
         dws_receptive_field=None,
         dws_layers=8,
         dws_channels=64,
@@ -82,6 +83,7 @@ def construct_convgnp(nps):
                 channels=unet_channels,
                 kernels=unet_kernels,
                 activations=unet_activations,
+                use_resize_convs=unet_use_resize_convs,
                 dtype=dtype,
             )
             receptive_field = conv.receptive_field / points_per_unit

--- a/neuralprocesses/tensorflow/nn.py
+++ b/neuralprocesses/tensorflow/nn.py
@@ -168,6 +168,10 @@ class Interface:
     Conv2d = partial(ConvNd, dim=2)
     Conv3d = partial(ConvNd, dim=3)
 
+    UpSampling1d = partial(UpSamplingNd, dim=1)
+    UpSampling2d = partial(UpSamplingNd, dim=2)
+    UpSampling3d = partial(UpSamplingNd, dim=3)
+
     ConvTransposed1d = partial(ConvNd, dim=1, transposed=True)
     ConvTransposed2d = partial(ConvNd, dim=2, transposed=True)
     ConvTransposed3d = partial(ConvNd, dim=3, transposed=True)

--- a/neuralprocesses/tensorflow/nn.py
+++ b/neuralprocesses/tensorflow/nn.py
@@ -85,6 +85,37 @@ def ConvNd(
         )
 
 
+def UpSamplingNd(
+    dim: int,
+    size: int = 2,
+    interp_method: str = 'bilinear',
+    dtype=None,
+):
+    # Only set `data_format` on the GPU: there is no CPU support.
+    if len(tf.config.list_physical_devices("GPU")) > 0:
+        data_format = "channels_first"
+    else:
+        data_format = "channels_last"
+
+    upsample_layer = getattr(tf.keras.layers, f"UpSampling{dim}D")(
+        size=size if dim == 1 else (size,) * dim,
+        interpolation=interp_method,
+        data_format=data_format,
+        dtype=dtype,
+    )
+
+    if data_format == "channels_first":
+        return upsample_layer
+    else:
+        return tf.keras.Sequential(
+            [
+                ChannelsToLast(dtype=dtype),
+                upsample_layer,
+                ChannelsToFirst(dtype=dtype),
+            ]
+        )
+
+
 def AvgPoolNd(
     dim: int,
     kernel: int,

--- a/neuralprocesses/torch/nn.py
+++ b/neuralprocesses/torch/nn.py
@@ -114,6 +114,10 @@ class Interface:
     Conv2d = partial(ConvNd, dim=2)
     Conv3d = partial(ConvNd, dim=3)
 
+    UpSampling1d = partial(UpSamplingNd, dim=1)
+    UpSampling2d = partial(UpSamplingNd, dim=2)
+    UpSampling3d = partial(UpSamplingNd, dim=3)
+
     ConvTransposed1d = partial(ConvNd, dim=1, transposed=True)
     ConvTransposed2d = partial(ConvNd, dim=2, transposed=True)
     ConvTransposed3d = partial(ConvNd, dim=3, transposed=True)

--- a/neuralprocesses/torch/nn.py
+++ b/neuralprocesses/torch/nn.py
@@ -58,6 +58,19 @@ def ConvNd(
     )
 
 
+def UpSamplingNd(
+    size: int = 2,
+    interp_method: str = 'bilinear',
+    dtype=None,
+):
+    return getattr(torch.nn, f"Upsample")(
+        # scalar multiplier applied over each dim automatically
+        scale_factor=size,
+        method=interp_method,
+        dtype=dtype,
+    )
+
+
 def AvgPoolNd(
     dim: int,
     kernel: int,


### PR DESCRIPTION
This PR addresses the issue of [checkerboard artifacts](https://distill.pub/2016/deconv-checkerboard/) in the existing `UNet` class. The problem is addressed by using resize-convolution layers in place of transposed convolutions. A boolean argument allows for reverting back to transposed convolutions, which should help with assessing the impact of this change.

Have tested for the 2D case with TensorFlow, but will be worth testing 1D and 3D and a PyTorch backend as well.

Please review - happy to make any changes.
