### PR TITLE
Non-learnable SetConv length scales

### DIFF
--- a/neuralprocesses/architectures/convgnp.py
+++ b/neuralprocesses/architectures/convgnp.py
@@ -384,7 +384,6 @@ def construct_convgnp(
     )
 
     # Set attribute `receptive_field`.
-    out.kv("Receptive field", receptive_field)
     model.receptive_field = receptive_field
 
     return model

--- a/neuralprocesses/coders/setconv/setconv.py
+++ b/neuralprocesses/coders/setconv/setconv.py
@@ -18,14 +18,17 @@ class SetConv:
     Args:
         scale (float): Initial value for the length scale.
         dtype (dtype, optional): Data type.
+        learnable (bool, optional): Whether the SetConv length scale is learnable.
 
     Attributes:
         log_scale (scalar): Logarithm of the length scale.
 
     """
 
-    def __init__(self, scale, dtype=None):
-        self.log_scale = self.nn.Parameter(B.log(scale), dtype=dtype)
+    def __init__(self, scale, dtype=None, learnable=True):
+        self.log_scale = self.nn.Parameter(
+            B.log(scale), dtype=dtype, learnable=learnable
+        )
 
 
 def _dim_is_concrete(x, i):

--- a/neuralprocesses/tensorflow/nn.py
+++ b/neuralprocesses/tensorflow/nn.py
@@ -332,19 +332,20 @@ class Interface:
     LayerNorm = staticmethod(LayerNorm)
 
     @staticmethod
-    def Parameter(x, dtype=None):
+    def Parameter(x, dtype=None, learnable=True):
         """A tracked parameter.
 
         Args:
             x (tensor): Initial value of the parameter.
             dtype (dtype, optional): Data type.
+            learnable (bool, optional): Whether the parameter is learnable.
 
         Returns:
             :class:`tf.Variable`: Parameter.
         """
         dtype = dtype or tf.float32
         dtype = convert(dtype, B.TFDType)
-        return tf.Variable(x, dtype=dtype)
+        return tf.Variable(x, dtype=dtype, trainable=learnable)
 
 
 interface = Interface()  #: The TensorFlow interface.

--- a/neuralprocesses/torch/nn.py
+++ b/neuralprocesses/torch/nn.py
@@ -240,12 +240,13 @@ class Interface:
     LayerNorm = staticmethod(LayerNorm)
 
     @staticmethod
-    def Parameter(x, dtype=None):
+    def Parameter(x, dtype=None, learnable=True):
         """A tracked parameter.
 
         Args:
             x (tensor): Initial value of the parameter.
             dtype (dtype, optional): Data type.
+            learnable (bool, optional): Whether the parameter is learnable.
 
         Returns:
             :class:`torch.nn.Parameter`: Parameter.
@@ -256,7 +257,7 @@ class Interface:
             x = torch.tensor(x, dtype=dtype)
         else:
             x = B.cast(dtype, x)
-        return torch.nn.Parameter(x, requires_grad=True)
+        return torch.nn.Parameter(x, requires_grad=learnable)
 
 
 interface = Interface()  #: The PyTorch interface.

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -118,6 +118,8 @@ def product_kw_args(config, **kw_args):
             dim_x=[1, 2],
             dim_y=[1, 2],
             likelihood=["het", "lowrank"],
+            encoder_scales_learnable=[True, False],
+            decoder_scale_learnable=[True, False],
         )
     )
     # ConvNP:


### PR DESCRIPTION
This PR addresses a problem I've experienced, whereby learnable SetConv length scales in the ConvGNP arch lead to encoder length scales shrinking to the point of producing checkerboard-like artifacts in the discretised density channel output by SetConv layers. This has the effect of injecting noise into the model as training progresses, leading to artifacts in the model predictions. I've addressed this by adding a parameter to hold the length scales fixed at their initialisation values:
- Added arguments to control whether the SetConv length scale is learnable
- Parameterised this in `construct_convgnp`, with the encoder and decoders parameterised separately
- Since the problem above may not be universal, I've defaulted all `learnable` args to `True`
- Added `construct_convgnp` unit tests. Are there any more tests I should add? I ran the tests locally and I think the only errors were due to numerical issues (eg Cholesky decomp). I also killed the tests at 98% completion, because the `test_predprey` and `test_eeg` tests were taking too long on my laptop.
- Removed the printing of the model's receptive field in `construct_convgnp`, as discussed with @wesselb 