### PR TITLE
Add LeakyRelu as an option in MLP nonlinearity

### DIFF
--- a/neuralprocesses/architectures/agnp.py
+++ b/neuralprocesses/architectures/agnp.py
@@ -29,6 +29,8 @@ def construct_agnp(*args, nps=nps, num_heads=8, **kw_args):
             `False`.
         num_dec_layers (int, optional): Number of layers in the decoder. Defaults to 6.
         width (int, optional): Widths of all intermediate MLPs. Defaults to 512.
+        nonlinearity (string, optional): Nonlinearity in the MLP layers. Must be one of
+        `"ReLU"`, and `"LeakyReLU"`. Defaults to `"ReLU"`.
         likelihood (str, optional): Likelihood. Must be one of `"het"` or `"lowrank"`.
             Defaults to `"lowrank"`.
         num_basis_functions (int, optional): Number of basis functions for the

--- a/neuralprocesses/architectures/gnp.py
+++ b/neuralprocesses/architectures/gnp.py
@@ -22,6 +22,7 @@ def construct_gnp(
     enc_same=False,
     num_dec_layers=6,
     width=512,
+    nonlinearity="ReLU",
     likelihood="lowrank",
     num_basis_functions=512,
     dim_lv=0,
@@ -54,6 +55,8 @@ def construct_gnp(
             `False`.
         num_dec_layers (int, optional): Number of layers in the decoder. Defaults to 6.
         width (int, optional): Widths of all intermediate MLPs. Defaults to 512.
+        nonlinearity (string, optional): Nonlinearity in the MLP layers. Must be one of
+        `"ReLU"`, and `"LeakyReLU"`. Defaults to `"ReLU"`.
         likelihood (str, optional): Likelihood. Must be one of `"het"` or `"lowrank"`.
             Defaults to `"lowrank"`.
         num_basis_functions (int, optional): Number of basis functions for the
@@ -101,6 +104,7 @@ def construct_gnp(
                 dim_embedding=dim_embedding,
                 num_heads=attention_num_heads,
                 num_enc_layers=num_enc_layers,
+                nonlinearity=nonlinearity,
                 dtype=dtype,
             )
 
@@ -126,6 +130,7 @@ def construct_gnp(
                 out_dim=dim_embedding,
                 num_layers=num_enc_layers,
                 width=width,
+                nonlinearity=nonlinearity,
                 dtype=dtype,
             )
 
@@ -158,6 +163,7 @@ def construct_gnp(
                 out_dim=dim_embedding,
                 num_layers=num_enc_layers,
                 width=width,
+                nonlinearity=nonlinearity,
                 dtype=dtype,
             )
 
@@ -179,6 +185,7 @@ def construct_gnp(
                 # The capacity of this MLP should increase with the number of outputs,
                 # but multiplying by `len(dim_yc)` is too aggressive.
                 width=width * min(len(dim_yc), 2),
+                nonlinearity=nonlinearity,
                 dtype=dtype,
             ),
             lv_likelihood,
@@ -211,6 +218,7 @@ def construct_gnp(
                     # The capacity of this MLP should increase with the number of
                     # outputs, but multiplying by `len(dim_yc)` is too aggressive.
                     width=width * min(len(dim_yc), 2),
+                    nonlinearity=nonlinearity,
                     dtype=dtype,
                 ),
                 selector,  # Select the right target output.

--- a/neuralprocesses/coders/attention.py
+++ b/neuralprocesses/coders/attention.py
@@ -16,9 +16,8 @@ class Attention:
         dim_embedding (int): Dimensionality of the embedding.
         num_heads (int): Number of heads.
         num_enc_layers (int): Number of layers in the encoders.
-        nonlinearity (string, optional): Nonlinearity in the encoders. Valid
-        values are None (defaults to ReLU), 'ReLU', and 'LeakyReLU'. Not
-        case-sensitive.
+        nonlinearity (string, optional): Nonlinearity in the encoders. Must be
+        one of `"ReLU"`, and `"LeakyReLU"`. Defaults to `"ReLU"`.
         dtype (dtype, optional): Data type.
 
     Attributes:
@@ -40,7 +39,7 @@ class Attention:
         dim_embedding,
         num_heads,
         num_enc_layers,
-        nonlinearity=None,
+        nonlinearity="ReLU",
         dtype=None,
         _self=False,
     ):

--- a/neuralprocesses/coders/attention.py
+++ b/neuralprocesses/coders/attention.py
@@ -16,6 +16,9 @@ class Attention:
         dim_embedding (int): Dimensionality of the embedding.
         num_heads (int): Number of heads.
         num_enc_layers (int): Number of layers in the encoders.
+        nonlinearity (string, optional): Nonlinearity in the encoders. Valid
+        values are None (defaults to ReLU), 'ReLU', and 'LeakyReLU'. Not
+        case-sensitive.
         dtype (dtype, optional): Data type.
 
     Attributes:
@@ -37,6 +40,7 @@ class Attention:
         dim_embedding,
         num_heads,
         num_enc_layers,
+        nonlinearity=None,
         dtype=None,
         _self=False,
     ):
@@ -49,12 +53,14 @@ class Attention:
             in_dim=dim_x,
             layers=(self.dim_head * num_heads,) * num_enc_layers,
             out_dim=self.dim_head * num_heads,
+            nonlinearity=nonlinearity,
             dtype=dtype,
         )
         self.encoder_xy = self.nps.MLP(
             in_dim=dim_x + dim_y,
             layers=(self.dim_head * num_heads,) * num_enc_layers,
             out_dim=self.dim_head * num_heads,
+            nonlinearity=nonlinearity,
             dtype=dtype,
         )
 
@@ -62,12 +68,14 @@ class Attention:
             in_dim=self.dim_head * num_heads,
             layers=(),
             out_dim=dim_embedding,
+            nonlinearity=nonlinearity,
             dtype=dtype,
         )
         self.mlp1 = self.nps.MLP(
             in_dim=self.dim_head * num_heads,
             layers=(),
             out_dim=dim_embedding,
+            nonlinearity=nonlinearity,
             dtype=dtype,
         )
         self.ln1 = self.nn.LayerNorm(dim_embedding, None, dtype=dtype)
@@ -75,6 +83,7 @@ class Attention:
             in_dim=dim_embedding,
             layers=(dim_embedding,),
             out_dim=dim_embedding,
+            nonlinearity=nonlinearity,
             dtype=dtype,
         )
         self.ln2 = self.nn.LayerNorm(dim_embedding, None, dtype=dtype)
@@ -140,6 +149,9 @@ class SelfAttention(Attention):
         dim_embedding (int): Dimensionality of the embedding.
         num_heads (int): Number of heads.
         num_enc_layers (int): Number of layers in the encoders.
+        nonlinearity (string, optional): Nonlinearity in the encoders. Valid
+        values are None (defaults to ReLU), 'ReLU', and 'LeakyReLU'.Not
+        case-sensitive.
         dtype (dtype, optional): Data type.
 
     Attributes:

--- a/neuralprocesses/coders/nn.py
+++ b/neuralprocesses/coders/nn.py
@@ -75,7 +75,7 @@ class MLP:
             nonlinearity = self.nn.LeakyReLU()
         else:
             raise ValueError(
-                "'nonlinearity' must be either [None], 'ReLU', or 'LeakyReLU'"
+                "'nonlinearity' must be either None, 'ReLU', or 'LeakyReLU'"
             )
             
         # Build layers.

--- a/neuralprocesses/coders/nn.py
+++ b/neuralprocesses/coders/nn.py
@@ -39,8 +39,8 @@ class MLP:
         layers (tuple[int, ...], optional): Width of every hidden layer.
         num_layers (int, optional): Number of hidden layers.
         width (int, optional): Width of the hidden layers
-        nonlinearity (string, optional): Nonlinearity. Valid values are None
-        (defaults to ReLU), 'ReLU', and 'LeakyReLU'. Not case-sensitive.
+        nonlinearity (string, optional): Nonlinearity. Must be one of
+        `"ReLU"`, and `"LeakyReLU"`. Defaults to `"ReLU"`.        
         dtype (dtype, optional): Data type.
 
     Attributes:
@@ -54,7 +54,7 @@ class MLP:
         layers: Optional[Tuple[int, ...]] = None,
         num_layers: Optional[int] = None,
         width: Optional[int] = None,
-        nonlinearity=None,
+        nonlinearity="ReLU",
         dtype=None,
     ):
         # Check that one of the two specifications is given.
@@ -75,7 +75,7 @@ class MLP:
             nonlinearity = self.nn.LeakyReLU()
         else:
             raise ValueError(
-                "'nonlinearity' must be either None, 'ReLU', or 'LeakyReLU'"
+                """'nonlinearity' must be either `ReLU`, or `LeakyReLU`"""
             )
             
         # Build layers.

--- a/neuralprocesses/coders/nn.py
+++ b/neuralprocesses/coders/nn.py
@@ -39,7 +39,8 @@ class MLP:
         layers (tuple[int, ...], optional): Width of every hidden layer.
         num_layers (int, optional): Number of hidden layers.
         width (int, optional): Width of the hidden layers
-        nonlinearity (function, optional): Nonlinearity.
+        nonlinearity (string, optional): Nonlinearity. Valid values are None
+        (defaults to ReLU), 'ReLU', and 'LeakyReLU'. Not case-sensitive.
         dtype (dtype, optional): Data type.
 
     Attributes:
@@ -68,9 +69,15 @@ class MLP:
             layers = (width,) * num_layers
 
         # Default to ReLUs.
-        if nonlinearity is None:
+        if nonlinearity is None or str(nonlinearity).lower() == 'relu':
             nonlinearity = self.nn.ReLU()
-
+        elif str(nonlinearity).lower() == 'leakyrelu':
+            nonlinearity = self.nn.LeakyReLU()
+        else:
+            raise ValueError(
+                "'nonlinearity' must be either [None], 'ReLU', or 'LeakyReLU'"
+            )
+            
         # Build layers.
         if len(layers) == 0:
             self.net = self.nn.Linear(in_dim, out_dim, dtype=dtype)

--- a/neuralprocesses/tensorflow/nn.py
+++ b/neuralprocesses/tensorflow/nn.py
@@ -270,6 +270,7 @@ class Interface:
     """TensorFlow interface."""
 
     ReLU = tf.keras.layers.ReLU
+    LeakyReLU = tf.keras.layers.LeakyReLU
 
     @staticmethod
     def Sequential(*modules):

--- a/neuralprocesses/torch/nn.py
+++ b/neuralprocesses/torch/nn.py
@@ -200,6 +200,7 @@ class Interface:
     """PyTorch interface."""
 
     ReLU = torch.nn.ReLU
+    LeakyReLU = torch.nn.LeakyReLU    
 
     Sequential = torch.nn.Sequential
 


### PR DESCRIPTION
Implemented in the MLP class, and constructer functions construct_gnp() and construct_agnp(). The nonlinearity argument changes from being a function to being a string that selects a nonlinearity from a predetermined list (currently just ReLU and LeakyReLU)