### PR TITLE
Add dtype_lik option to nps.predict

### DIFF
--- a/neuralprocesses/model/predict.py
+++ b/neuralprocesses/model/predict.py
@@ -31,7 +31,7 @@ def predict(
         num_samples (int, optional): Number of samples to produce. Defaults to 50.
         batch_size (int, optional): Batch size. Defaults to 16.
         dtype_lik (dtype, optional): Data type to use for the likelihood computation.
-            Defaults to the 64-bit variant of the data type of `yt`.
+            Defaults to the 64-bit variant of the data type of `xt`.
 
     Returns:
         random state, optional: Random state.
@@ -43,7 +43,7 @@ def predict(
     float = B.dtype_float(xt)
 
     # For the likelihood computation, default to using a 64-bit version of the data
-    # type of `yt`.
+    # type of `xt`.
     if not dtype_lik:
         dtype_lik = B.promote_dtypes(float, np.float64)
 

--- a/neuralprocesses/model/predict.py
+++ b/neuralprocesses/model/predict.py
@@ -18,6 +18,7 @@ def predict(
     *,
     num_samples=50,
     batch_size=16,
+    dtype_lik=None
 ):
     """Use a model to predict.
 
@@ -29,6 +30,8 @@ def predict(
         xt (input): Inputs of the target set.
         num_samples (int, optional): Number of samples to produce. Defaults to 50.
         batch_size (int, optional): Batch size. Defaults to 16.
+        dtype_lik (dtype, optional): Data type to use for the likelihood computation.
+            Defaults to the 64-bit variant of the data type of `yt`.
 
     Returns:
         random state, optional: Random state.
@@ -39,6 +42,11 @@ def predict(
     """
     float = B.dtype_float(xt)
     float64 = B.promote_dtypes(float, np.float64)
+
+    # For the likelihood computation, default to using a 64-bit version of the data
+    # type of `yt`.
+    if not dtype_lik:
+        dtype_lik = float64
 
     # Collect noiseless samples, noisy samples, first moments, and second moments.
     ft, yt = [], []
@@ -54,8 +62,7 @@ def predict(
             contexts,
             xt,
             dtype_enc_sample=float,
-            # Run likelihood with `float64`s to ease the numerics as much as possible.
-            dtype_lik=float64,
+            dtype_lik=dtype_lik,
             num_samples=this_num_samples,
         )
 
@@ -90,6 +97,7 @@ def predict(
         m2s.append(B.add(pred.var, B.multiply(m1s[-1], m1s[-1])))
 
         done_num_samples += this_num_samples
+
 
     # Stack samples.
     ft = B.concat(*ft, axis=0)

--- a/neuralprocesses/model/predict.py
+++ b/neuralprocesses/model/predict.py
@@ -41,12 +41,11 @@ def predict(
         tensor: `num_samples` noisy samples.
     """
     float = B.dtype_float(xt)
-    float64 = B.promote_dtypes(float, np.float64)
 
     # For the likelihood computation, default to using a 64-bit version of the data
     # type of `yt`.
     if not dtype_lik:
-        dtype_lik = float64
+        dtype_lik = B.promote_dtypes(float, np.float64)
 
     # Collect noiseless samples, noisy samples, first moments, and second moments.
     ft, yt = [], []

--- a/neuralprocesses/model/predict.py
+++ b/neuralprocesses/model/predict.py
@@ -97,7 +97,6 @@ def predict(
 
         done_num_samples += this_num_samples
 
-
     # Stack samples.
     ft = B.concat(*ft, axis=0)
     yt = B.concat(*yt, axis=0)


### PR DESCRIPTION
Hi Wessel!

Problem: Apple silicon GPUs don't support FP64. So when running nps.predict on the GPU when using pytorch, there would be an error because dtype_lik was forced to be float64:

> TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.

Solution: I've added dtype_lik as an optional argument to nps.predict, very similar to how it is implemented in elbo and loglik